### PR TITLE
Add dynamic default & static musl Rust benchmarks

### DIFF
--- a/noop.rs
+++ b/noop.rs
@@ -1,0 +1,3 @@
+fn main() {
+    std::process::exit(42);
+}


### PR DESCRIPTION
Remembered that you had this repo during an argument the other day. Here's Rust with both default compilation options (linking dynamically against system libc) and statically linked (against musl, as `rustc` does not support static linking with glibc).

There's also a [WIP branch](https://github.com/tazjin/benchmarking-uselessness/tree/feat/rust-nostd)  without the Rust standard library, but the build process for that is a bit ugly and the binary currently still contains the stdlib as a dependency.